### PR TITLE
[correct_error_override_check]: Check for override on error before ch…

### DIFF
--- a/compysition/event.py
+++ b/compysition/event.py
@@ -221,7 +221,7 @@ class Event(object):
 
     def format_error(self):
         if self.error:
-            if self.error.override:
+            if hasattr(self.error, 'override') and self.error.override:
                 return self.error.override
             else:
                 messages = self.error.message


### PR DESCRIPTION
…ecking to see if it's set. This is to account for errors where the error does not have an attribute named override