### PR TITLE
Fix HTTP server reported response time

### DIFF
--- a/compysition/actors/httpserver.py
+++ b/compysition/actors/httpserver.py
@@ -282,7 +282,8 @@ class HTTPServer(Actor, Bottle):
 
             response_queue.put(local_response)
             response_queue.put(StopIteration)
-            self.logger.info("[{status}] Returned in {time} ms".format(status=local_response.status, time=(datetime.now()-event.created).microseconds / 1000), event=event)
+            self.logger.info("[{status}] Returned in {time:0.0f} ms".format(
+                status=local_response.status, time=(datetime.now()-event.created).total_seconds() * 1000), event=event)
         else:
             self.logger.warning("Received event response for an unknown event ID. The request might have already received a response", event=event)
 


### PR DESCRIPTION
The microseconds attribute of a timedelta object only returns a max
  of 1000000 microseconds. If the timedelta is representing a time diff
  of greater than 1000000 microseconds, the timedelta.seconds attribute
  will contain the seconds, and the microseconds attribute
  will tick back to 0 to represent the next 1000000 microseconds. Eg. a
  timedelta(d) object representing 3.5 seconds will have d.seconds=3
  and d.microseconds=500000

  This led to us always reporting a sub (or exactly) 1 second response
  time, even if the request took much longer.

  total_seconds() does the right thing and combines timedelta.seconds
  and timedelta.microseconds to return total seconds as a floating point
  e.g. time delta of 3.5 seconds returns 3.50000