### PR TITLE
defined some dependencies; refined pytest setup; added unitests; remo…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ clean-pyc: ## remove Python file artifacts
 	find . -name '__pycache__' -exec rm -fr {} +
 
 install: clean ## install the package to the active Python's site-packages
+	python -m pip install -U pip
+	python -m pip install -U webcolors
+	python -m pip install -U funcparserlib
+	python -m pip install -U setuptools==43.0.0
 	python setup.py install
 
 test: test-py2 test-py3
@@ -32,7 +36,7 @@ test-run: install
 
 install-pytest:
 	sudo apt-get install -y python-logilab-common
-	pip install -U pip pytest pytest-cov pytest-socket
+	python -m pip install -U pip pytest==4.6.8 pytest-cov pytest-socket
 
 install-pyenv:
 	sudo apt-get install -y git
@@ -40,9 +44,12 @@ install-pyenv:
 	rm -f ~/bin/pyenv
 	git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 	ln -s ~/.pyenv/bin/pyenv ~/bin/pyenv
-	pyenv init -
+	eval "$(pyenv init -)"
 	pyenv install 2.7.6
 	pyenv install 3.6.5
+
+install-2.7.6: test-setpy2 install install-pytest
+install-3.6.5: test-setpy3 install install-pytest
 
 dependencies:
 	sudo apt-get install -y \
@@ -60,9 +67,9 @@ dependencies:
 		cmake \
 		imagemagick \
 		libssl-dev \
-		libzmq-dev \
+		libzmq3-dev \
 		libmysqlclient-dev \
-		python-pip
-	pip install -U pip
-
-install-dev-env: dependencies install-pytest install install-pyenv
+		python-pip \
+		libsqlite3-dev
+	
+install-dev-env: dependencies install-pyenv install-3.6.5 install-2.7.6

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ dependencies:
 		cmake \
 		imagemagick \
 		libssl-dev \
-		libzmq3-dev \
+		libzmq-dev \
 		libmysqlclient-dev \
 		python-pip \
 		libsqlite3-dev

--- a/Makefile
+++ b/Makefile
@@ -18,24 +18,25 @@ clean-pyc: ## remove Python file artifacts
 	find . -name '__pycache__' -exec rm -fr {} +
 
 install: clean ## install the package to the active Python's site-packages
-	python -m pip install -U pip
-	python -m pip install -U webcolors
-	python -m pip install -U funcparserlib
-	python -m pip install -U setuptools==43.0.0
 	python setup.py install
 
 test: test-py2 test-py3
 test-py2: test-setpy2 test-run
 test-py3: test-setpy3 test-run
 test-setpy3:
+	eval "$(pyenv init -)"
 	pyenv global 3.6.5
 test-setpy2:
+	eval "$(pyenv init -)"
 	pyenv global 2.7.6
 test-run: install
+	eval "$(pyenv init -)"
+	python -V
 	python -m pytest
 
 install-pytest:
 	sudo apt-get install -y python-logilab-common
+	eval "$(pyenv init -)"
 	python -m pip install -U pip pytest==4.6.8 pytest-cov pytest-socket
 
 install-pyenv:
@@ -48,8 +49,15 @@ install-pyenv:
 	pyenv install 2.7.6
 	pyenv install 3.6.5
 
-install-2.7.6: test-setpy2 install install-pytest
-install-3.6.5: test-setpy3 install install-pytest
+pre_install:
+	eval "$(pyenv init -)"
+	python -m pip install -U pip
+	python -m pip install -U webcolors
+	python -m pip install -U funcparserlib
+	python -m pip install -U setuptools==43.0.0
+
+install-2.7.6: test-setpy2 pre_install install install-pytest
+install-3.6.5: test-setpy3 pre_install install install-pytest
 
 dependencies:
 	sudo apt-get install -y \
@@ -66,10 +74,11 @@ dependencies:
 		liblcms2-dev \
 		cmake \
 		imagemagick \
-		libssl-dev \
-		libzmq-dev \
-		libmysqlclient-dev \
+		libssl1.0-dev \
+		libzmq3-dev \
 		python-pip \
-		libsqlite3-dev
-	
+		libsqlite3-dev 
+
 install-dev-env: dependencies install-pyenv install-3.6.5 install-2.7.6
+	eval "$(pyenv init -)"
+	pyenv global system

--- a/compysition/actors/httpserver.py
+++ b/compysition/actors/httpserver.py
@@ -160,6 +160,7 @@ class HTTPServer(Actor, Bottle):
     X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded"
 
     WSGI_SERVER_CLASS = pywsgi.WSGIServer
+
     def combine_base_paths(self, route, named_routes):
         base_path_id = route.get('base_path', None)
         if base_path_id:
@@ -230,7 +231,7 @@ class HTTPServer(Actor, Bottle):
                     route['method'] = []
 
                 self.logger.debug("Configured route '{path}' with methods '{methods}'".format(path=route['path'], methods=route['method']))
-                self.route(callback=callback, atypes=["app/data"], **route)#ctypes here will trigger restrictions on content-type
+                self.route(callback=callback, **route)
 
         self.wsgi_app = self
         self.wsgi_app.install(ContentTypePlugin())

--- a/compysition/actors/httpserver.py
+++ b/compysition/actors/httpserver.py
@@ -46,7 +46,17 @@ class ContentTypePlugin(object):
                            "text/html",
                            "application/json",
                            "application/x-www-form-urlencoded")
-
+    '''
+    # with the change to the apply function the DEFAULT_VALID_TYPES should be as follows to match content-type/event mapping
+    DEFAULT_VALID_TYPES = ("text/xml",
+                           "application/xml",
+                           "text/plain",
+                           "text/html",
+                           "application/json",
+                           "application/x-www-form-urlencoded",
+                           "application/json+schema",
+                           "application/xml+schema")
+    '''
     name = "ctypes"
     api = 2
 
@@ -54,6 +64,9 @@ class ContentTypePlugin(object):
         self.default_types = default_types or self.DEFAULT_VALID_TYPES
 
     def apply(self, callback, route):
+        #ATTENTION
+        #Bottle expects a decorator
+        #This should be implemented as below
         ctype = request.content_type.split(';')[0]
         ignore_ctype = route.config.get('ignore_ctype', False) or request.content_length < 1
         if ignore_ctype or ctype in route.config.get('ctypes', self.default_types):
@@ -61,6 +74,17 @@ class ContentTypePlugin(object):
         else:
             raise HTTPError(415, "Unsupported Content-Type '{_type}'".format(_type=ctype))
 
+    '''
+    def apply(self, callback, route):
+        def callback_wrapper(*args, **kwargs):
+            ctype = request.content_type.split(';')[0]
+            ignore_ctype = route.config.get('ignore_ctype', False) or request.content_length < 1
+            if ignore_ctype or ctype in route.config.get('ctypes', self.default_types):
+                return callback(*args, **kwargs)
+            else:
+                raise HTTPError(415, "Unsupported Content-Type '{_type}'".format(_type=ctype))
+        return callback_wrapper
+    '''
 
 class HTTPServer(Actor, Bottle):
     """**Receive events over HTTP.**
@@ -135,6 +159,7 @@ class HTTPServer(Actor, Bottle):
     X_WWW_FORM_URLENCODED_KEY_MAP = defaultdict(lambda: HttpEvent, {"XML": XMLHttpEvent, "JSON": JSONHttpEvent})
     X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded"
 
+    WSGI_SERVER_CLASS = pywsgi.WSGIServer
     def combine_base_paths(self, route, named_routes):
         base_path_id = route.get('base_path', None)
         if base_path_id:
@@ -205,7 +230,7 @@ class HTTPServer(Actor, Bottle):
                     route['method'] = []
 
                 self.logger.debug("Configured route '{path}' with methods '{methods}'".format(path=route['path'], methods=route['method']))
-                self.route(callback=callback, **route)
+                self.route(callback=callback, atypes=["app/data"], **route)#ctypes here will trigger restrictions on content-type
 
         self.wsgi_app = self
         self.wsgi_app.install(ContentTypePlugin())
@@ -258,7 +283,6 @@ class HTTPServer(Actor, Bottle):
 
     def consume(self, event, *args, **kwargs):
         # There is an error that results in responding with an empty list that will cause an internal server error
-
         original_event_class, response_queue = self.responders.pop(event.event_id, None)
 
         if response_queue:
@@ -381,14 +405,16 @@ class HTTPServer(Actor, Bottle):
         return local_response
 
     def post_hook(self):
+        self.__server.close()
         self.__server.stop()
+        self.__server.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.logger.info("Stopped serving")
 
     def __serve(self):
         if self.keyfile is not None and self.certfile is not None:
-            self.__server = pywsgi.WSGIServer((self.address, self.port), self, keyfile=self.keyfile, certfile=self.certfile)
+            self.__server = self.WSGI_SERVER_CLASS((self.address, self.port), self, keyfile=self.keyfile, certfile=self.certfile)
         else:
-            self.__server = pywsgi.WSGIServer((self.address, self.port), self, log=None)
+            self.__server = self.WSGI_SERVER_CLASS((self.address, self.port), self, log=None)
         self.logger.info("Serving on {address}:{port}".format(address=self.address, port=self.port))
         self.__server.start()
 

--- a/compysition/actors/smtp.py
+++ b/compysition/actors/smtp.py
@@ -12,7 +12,7 @@ import traceback
 import re
 
 from email.mime.text import MIMEText
-from bs4 import BeautifulSoup
+#from bs4 import BeautifulSoup
 
 from compysition.actor import Actor
 from compysition.event import XMLEvent, JSONEvent

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,7 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
-addopts = --disable-socket -v --cov=compysition
+addopts = -v --cov=compysition
+
+[extra]
+addopts = -v --cov=compysition --disable-socket

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ try:
         VERSION = re.search("__version__\s*=\s*'(.*)'", init.read(), re.M).group(1)
 except (AttributeError, IndexError, OSError, IOError) as e:
     VERSION = ''
+
 REQUIRES = [
             "gevent",
             "greenlet",
@@ -40,14 +41,15 @@ REQUIRES = [
             "pycrypto",
             "configobj",
             "lxml",
-            "Pillow",
+            "Pillow==6.2.1",
             "blockdiag",
             "bottle",
             "xmltodict",
-            "jsonschema",
-            "bs4",
+            "jsonschema==2.6.0",
             "apscheduler",
-            "mimeparse"]
+            "mimeparse",
+            "requests"
+            ]
 
 try:
      with open('README.rst', 'rt') as readme:

--- a/tests/actors/test_httpserver.py
+++ b/tests/actors/test_httpserver.py
@@ -1,9 +1,159 @@
 import json
+from lxml import etree
 import unittest
+from contextlib import contextmanager
 
 from compysition.actors.httpserver import HTTPServer
 from compysition.event import JSONHttpEvent, HttpEvent, XMLHttpEvent
 from compysition.testutils.test_actor import TestActorWrapper
+from compysition.queue import Queue
+import requests
+from compysition.errors import ResourceNotFound, InvalidEventDataModification
+
+import socket
+from contextlib import closing
+from gevent import sleep
+import pytest
+from gevent.pywsgi import WSGIHandler, WSGIServer
+import mimetools
+from StringIO import StringIO
+
+class HTTPServerTestWrapper:
+
+    class MockHandler(WSGIHandler):
+
+        def __init__(self, sock=None, address=None, server=None, *args, **kwargs):
+            self.wrapper = server.wrapper
+            self.wrapper._handler = self
+            super(HTTPServerTestWrapper.MockHandler, self).__init__(sock, address, server, rfile=StringIO(""), *args, **kwargs)
+            self.header_data = None
+
+        def read_requestline(self):
+            return "%s %s HTTP/1.1" % (self.mocked_method.upper(), self.mocked_path)
+            
+        def __break_message(self, message, split="\n"):
+            lines = str(message).split(split)
+            oh = {}
+            for line in lines:
+                header, value = line.split(":", 1)
+                header, value = header.strip(), value.strip()
+                oh[header] = value
+            return oh
+
+        def __build_message(self, json):
+            message_lines = []
+            for header, value in json.iteritems():
+                message_lines.append("%s: %s" % (header, value))
+            return mimetools.Message(StringIO("\n".join(message_lines)))
+
+        def __get_case_insensitive_header(self, target_header):
+            for header, value in self.mocked_headers.iteritems():
+                if header.lower() == target_header.lower():
+                    return value
+            return None
+
+        def read_request(self, raw_requestline, *args, **kwargs):
+            self.command, self.path, self.request_version = raw_requestline.split()
+            self.close_connection = False
+            self.content_length = self.__get_case_insensitive_header(target_header="Content-Length")
+            self.headers = self.__build_message(json=self.mocked_headers)
+            return True
+
+        def get_environ(self):
+            old_rfile = self.rfile
+            self.rfile = StringIO(self.mocked_content)
+            env = super(HTTPServerTestWrapper.MockHandler, self).get_environ()
+            self.rfile = old_rfile
+            return env
+
+        def __pop_first_line(self, data, split="\n"):
+            lines = data.split(split)
+            lines = [line for line in lines if len(line.strip()) > 0]
+            return split.join(lines[1:])
+
+        def _sendall(self, *args, **kwargs):
+            data = str(args[0])
+            if self.header_data is None:
+                data = self.__pop_first_line(data=data, split="\r\n")
+                self.header_data = self.__break_message(message=data, split="\r\n")
+            else:
+                self.wrapper.responses.append((self.header_data, data))
+                self.header_data = None
+            
+    class MockWSGIServer(WSGIServer):
+        def __init__(self, socket, application, *args, **kwargs):
+            self.wrapper = application.wrapper
+            self.wrapper._server = self
+            super(HTTPServerTestWrapper.MockWSGIServer, self).__init__(socket, application, *args, **kwargs)
+            self.handler_class = HTTPServerTestWrapper.MockHandler
+            handler = self.handler_class(server=self)
+            HTTPServerTestWrapper._server = self
+
+    class MockHttpServer(HTTPServer):
+        def __init__(self, wrapper, *args, **kwargs):
+            self.wrapper = wrapper
+            self.wrapper._http_server = self
+            super(HTTPServerTestWrapper.MockHttpServer, self).__init__(*args, **kwargs)
+            self.WSGI_SERVER_CLASS = HTTPServerTestWrapper.MockWSGIServer
+
+    def __init__(self, *args, **kwargs):
+        self._handler = None
+        self._server = None
+        self._http_server = None
+        self.responses = []
+
+    def create_httpserver(self, *args, **kwargs):
+        #creates Mocked HTTPServer
+        if self._http_server is not None:
+            raise Exception("Wrapper Already Has An Existing Server")
+        kwargs["port"] = kwargs.get("port", self.find_free_port())
+        kwargs["address"] = kwargs.get("address", "0.0.0.0")
+        self._http_server = HTTPServerTestWrapper.MockHttpServer(self, *args, **kwargs)
+        self._http_server.register_consumer("hidden_response_queue", Queue(name="hidden_response_queue"))
+        return self._http_server
+
+    def send_request(self, method, path="/", host="localhost", headers={}, body=""):
+        #inserts mock data into necessary places and kicks off request processing
+        #actual requests submitted via mocked server will error
+        body = str(body)
+        default_headers = {
+            "Host": host,
+            "Connection": "keep-alive",
+            "Accept-Encoding": "gzip, deflate",
+            "User-Agent": "python-requests/2.23.0",
+            "Content-Length": len(body)
+        }
+        self._handler.mocked_headers = default_headers
+        self._handler.mocked_headers.update(headers)
+        self._handler.mocked_method = method
+        self._handler.mocked_host = host
+        self._handler.mocked_path = path
+        self._handler.mocked_content = body
+        self._http_server.threads.spawn(self._handler.handle_one_request, restart=False)
+        sleep(0)
+
+    def get_response(self, event):
+        if len(self.responses) < 1:
+            self._http_server.pool.inbound["hidden_response_queue"].put(event)
+            sleep(0)
+            sleep(0)
+            sleep(0)
+        return self.responses.pop(0)
+
+    def find_free_port(self,):
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            s.bind(('', 0))
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            return s.getsockname()[1]
+
+parser = etree.XMLParser(remove_blank_text=True)
+#used to ignore formatting differences and focus on basic XML structure
+def xml_formatter(xml_str):
+    return etree.tostring(etree.XML(xml_str, parser=parser))
+
+#used to ignore formatting differences and focus on basic JSON structure
+def json_formatter(json_str):
+    return json.dumps(json.loads(json_str))
 
 class TestHTTPServer(unittest.TestCase):
     """
@@ -13,6 +163,9 @@ class TestHTTPServer(unittest.TestCase):
     every test. Wrote a decorator that wrapped the test_* methods and did that automatically, but it felt kind of dirty.
     Could re-vist that or a similar idea if repeating gets to annoying
     """
+    '''
+    Each test should be self contained and capable of passing without other tests
+    '''
     def setUp(self):
         self.actor = TestActorWrapper(HTTPServer("actor", address="0.0.0.0", port=8123))
 
@@ -25,7 +178,6 @@ class TestHTTPServer(unittest.TestCase):
         self.actor.input = _input_event
         output = self.actor.output
         self.assertEqual(output.headers['Content-Type'], 'text/plain')
-
 
     def test_content_type_json_event(self):
         _input_event = JSONHttpEvent()
@@ -78,5 +230,440 @@ class TestHTTPServer(unittest.TestCase):
         self.actor.input = _input_event
         output = self.actor.output
         self.assertEqual(json.loads(output.body), expected)
+        self.actor.stop()
+
+    def test_service_routing(self):
+        routes_config = {"routes":[{"id": "base","path": "/<queue:re:[a-zA-Z_0-9]+?>","method": ["POST"]}]}
+        wrapper = HTTPServerTestWrapper()
+        actor = wrapper.create_httpserver("http_server", routes_config=routes_config)
+        actor.pool.outbound.add("sample_service_1")
+        actor.pool.outbound.add("sample_service_2")
+        actor.pool.outbound.add("sample_service_3")
+        actor.pool.inbound.add("error")
+        actor.start()
+        data_obj = json.dumps({"data":123})
+
+        #baseline
+        assert len(actor.pool.outbound["sample_service_1"]) == 0
+        assert len(actor.pool.outbound["sample_service_2"]) == 0
+        assert len(actor.pool.outbound["sample_service_3"]) == 0
+        assert len(actor.pool.inbound["error"]) == 0
+
+        #missing queue
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"application/json"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service_1"]) == 0
+        assert len(actor.pool.outbound["sample_service_2"]) == 0
+        assert len(actor.pool.outbound["sample_service_3"]) == 0
+        assert len(actor.pool.inbound["error"]) == 1
+
+        #sample_service_1
+        wrapper.send_request(method="POST", path="/sample_service_1", headers={"Content-Type":"application/json"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service_1"]) == 1
+        assert len(actor.pool.outbound["sample_service_2"]) == 0
+        assert len(actor.pool.outbound["sample_service_3"]) == 0
+        assert len(actor.pool.inbound["error"]) == 1
+
+        #sample_service_2
+        wrapper.send_request(method="POST", path="/sample_service_2", headers={"Content-Type":"application/json"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service_1"]) == 1
+        assert len(actor.pool.outbound["sample_service_2"]) == 1
+        assert len(actor.pool.outbound["sample_service_3"]) == 0
+        assert len(actor.pool.inbound["error"]) == 1
+
+        #sampl_service_3
+        wrapper.send_request(method="POST", path="/sample_service_3", headers={"Content-Type":"application/json"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service_1"]) == 1
+        assert len(actor.pool.outbound["sample_service_2"]) == 1
+        assert len(actor.pool.outbound["sample_service_3"]) == 1
+        assert len(actor.pool.inbound["error"]) == 1
+
+        actor.stop()
+
+    def test_content_type(self):
+        routes_config = {"routes":[{"id": "base","path": "/<queue:re:[a-zA-Z_0-9]+?>","method": ["POST"]}]}
+        wrapper = HTTPServerTestWrapper()
+        actor = wrapper.create_httpserver("http_server", routes_config=routes_config)
+        actor.pool.outbound.add("sample_service")
+        actor.pool.inbound.add("error")
+        actor.start()
+
+        #application/json
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        data_obj = json.dumps({"data":123})
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"application/json"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, JSONHttpEvent)
+        assert json_formatter(event.data_string()) == json_formatter(data_obj)
+
+        #ATTENTION
+        #application/json+schema
+        #should fail given logic in ContentTypePlugin
+        #however the current ContentTypePlugin implementation only applies to the first request submitted to HttpServer
+        #these tests would not be true if placed before prior content-type check
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        data_obj = json.dumps({"data":123})
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"application/json+schema"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, JSONHttpEvent)
+        assert json_formatter(event.data_string()) == json_formatter(data_obj)
+
+        #application/json
+        #with xml/invalid input
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        assert len(actor.pool.inbound["error"]) == 0
+        data_obj = "<data>123</data>"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"application/json"}, body=data_obj)
+        assert len(actor.pool.inbound["error"]) == 1
+        event = actor.pool.inbound["error"].get(block=True)
+        assert isinstance(event.error, InvalidEventDataModification)
+
+        #application/xml+schema
+        #should fail (but doesn't) similar to application/json+schema
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        data_obj = "<data>123</data>"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"application/xml+schema"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, XMLHttpEvent)
+        assert xml_formatter(event.data_string()) == xml_formatter(data_obj)
+
+        #application/xml
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        data_obj = "<data>123</data>"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"application/xml"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, XMLHttpEvent)
+        assert xml_formatter(event.data_string()) == xml_formatter(data_obj)
+
+        #text/plain
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        data_obj = "some random string"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"text/plain"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, HttpEvent)
+        assert event.data_string() == data_obj
+
+        #text/html
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        data_obj = "<data>123</data>"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"text/html"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, XMLHttpEvent)
+        assert xml_formatter(event.data_string()) == xml_formatter(data_obj)
+
+        #text/xml
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        data_obj = "<data>123</data>"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"text/xml"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, XMLHttpEvent)
+        assert xml_formatter(event.data_string()) == xml_formatter(data_obj)
+
+        #text/xml
+        #with json/invalid data
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        assert len(actor.pool.inbound["error"]) == 0
+        data_obj = json.dumps({"data":123})
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"text/xml"}, body=data_obj)
+        assert len(actor.pool.inbound["error"]) == 1
+        event = actor.pool.inbound["error"].get(block=True)
+        assert isinstance(event.error, InvalidEventDataModification)
+        
+        #application/x-www-form-urlencoded
+        #with XML data
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        data_obj = "XML=<data>123</data>"
+        data_obj2 = "<data>123</data>"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"application/x-www-form-urlencoded"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, XMLHttpEvent)
+        assert xml_formatter(event.data_string()) == xml_formatter(data_obj2)
+
+        #application/x-www-form-urlencoded
+        #with JSON data
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        data_obj2 = json.dumps({"data":123})
+        data_obj = "JSON=%s" % data_obj2
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"application/x-www-form-urlencoded"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, JSONHttpEvent)
+        assert json_formatter(event.data_string()) == json_formatter(data_obj2)
+
+        #ATTENTION
+        #application/x-www-form-urlencoded
+        #with form data
+        #this doesn't seem right
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        data_obj = "parm1=value1&parm2=value2"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"application/x-www-form-urlencoded"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, HttpEvent)
+        assert event.data_string() == "value2"
+        #I think one of these should be true
+        #assert event.data_string() == data_obj
+        #assert json_formatter(event.data_string()) == json_formatter(json.dumps({"parm1":"value1","parm2":value2"}))
+
+        #ATTENTION
+        #application/x-www-form-urlencoded
+        #with string data
+        #this doesn't seem right
+        #I think this should through an error
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        data_obj = "some random string"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":"application/x-www-form-urlencoded"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, HttpEvent)
+        assert event.data_string() == 'None'
+
+        #ATTENTION
+        #No Content-Type
+        #with string data
+        #content-type defaults to JSONHttpEvent
+        #I'm thinking this should be HttpEvent
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        assert len(actor.pool.inbound["error"]) == 0
+        data_obj = "some random string"
+        wrapper.send_request(method="POST", path="/sample_service", headers={}, body=data_obj)
+        assert len(actor.pool.inbound["error"]) == 1
+        event = actor.pool.inbound["error"].get(block=True)
+        assert isinstance(event, JSONHttpEvent)
+        assert isinstance(event.error, InvalidEventDataModification)
+
+        #ATTENTION
+        #No Content-Type
+        #with json data
+        #content-type defaults to JSONHttpEvent
+        #I'm thinking this should be HttpEvent
+        #Also this should fail if ContentTypePlugin worked correctly
+        assert len(actor.pool.outbound["sample_service"]) == 0
+        data_obj = json.dumps({"data":123})
+        wrapper.send_request(method="POST", path="/sample_service", headers={}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, JSONHttpEvent)
+        assert json_formatter(event.data_string()) == json_formatter(data_obj)
+
+        actor.stop()
+
+    def test_accepts(self):
+        '''
+            Not testing conversions just that conversion occur
+        '''
+        routes_config = {"routes":[{"id": "base","path": "/<queue:re:[a-zA-Z_0-9]+?>","method": ["POST"]}]}
+        wrapper = HTTPServerTestWrapper()
+        actor = wrapper.create_httpserver("http_server", routes_config=routes_config)
+        actor.pool.outbound.add("sample_service")
+        
+        actor.start()
+
+        #content_type = application/json
+        #accept = None
+        #response_event = JSONHttpEvent
+        data_obj = json.dumps({"data":123})
+        content_type = "application/json"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":content_type}, body=data_obj)
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, JSONHttpEvent)
+        headers, data = wrapper.get_response(event=event)
+        assert headers["Content-Type"] == content_type
+        assert json_formatter(data) == json_formatter(data_obj)
+
+        #content_type = application/json
+        #accept = application/xml
+        #response_event = JSONHttpEvent
+        data_obj = json.dumps({"data":123})
+        content_type, accept = "application/json", "application/xml"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":content_type, "Accept":accept}, body=data_obj)
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, JSONHttpEvent)
+        headers, data = wrapper.get_response(event=event)
+        assert headers["Content-Type"] == accept
+        event = XMLHttpEvent()
+        event.data = json.loads(data_obj)
+        assert xml_formatter(data) == xml_formatter(event.data_string())
+
+        #ATTENTION
+        #content_type = application/json
+        #accept = text/plain
+        #response_event = JSONHttpEvent
+        data_obj = json.dumps({"data":123})
+        content_type, accept = "application/json", "text/plain"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":content_type, "Accept":accept}, body=data_obj)
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, JSONHttpEvent)
+        headers, data = wrapper.get_response(event=event)
+        #should this not be 'text/plain'
+        #I understand there is no good way to convert json to plain text (other than json as a string) so maybe just 'SUCCESS'/'ERROR'??
+        #Regardless of data I think the header should be this
+        #assert headers["Content-Type"] == accept
+        assert headers["Content-Type"] == content_type
+        assert json_formatter(data) == json_formatter(data_obj)
+
+        #ATTENTION
+        #content_type = application/json
+        #accept = text/html
+        #response_event = JSONHttpEvent
+        data_obj = json.dumps({"data":123})
+        content_type, accept = "application/json", "application/xml"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type":content_type, "Accept":accept}, body=data_obj)
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, JSONHttpEvent)
+        headers, data = wrapper.get_response(event=event)
+        assert headers["Content-Type"] == accept
+        #XML and HTML are not necessarily the same maybe a new HTMLEvent down the road?
+        event = XMLHttpEvent()
+        event.data = json.loads(data_obj)
+        assert xml_formatter(data) == xml_formatter(event.data_string())
+        
+        #ATTENTION
+        #content_type = None
+        #accept = application/json
+        #response_event = JSONHttpEvent
+        #this should return error but doesn't due to ContentTypePlugin not being a decorator
+        data_obj = json.dumps({"data":123})
+        accept = "application/json"
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Accept":accept}, body=data_obj)
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, JSONHttpEvent)
+        headers, data = wrapper.get_response(event=event)
+        assert headers["Content-Type"] == accept
+        assert json_formatter(data) == json_formatter(data_obj)
+
+        #ATTENTION
+        #content_type = None
+        #accept = None
+        #response_event = JSONHttpEvent
+        #this should return error but doesn't due to ContentTypePlugin not being a decorator
+        data_obj = json.dumps({"data":123})
+        accept = "application/json"
+        wrapper.send_request(method="POST", path="/sample_service", headers={}, body=data_obj)
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        assert isinstance(event, JSONHttpEvent)
+        headers, data = wrapper.get_response(event=event)
+        assert headers["Content-Type"] == accept
+        assert json_formatter(data) == json_formatter(data_obj)
+        actor.stop()
+
+    def test_response_data_wrapper(self):
+        routes_config = {"routes":[{"id": "base","path": "/<queue:re:[a-zA-Z_0-9]+?>","method": ["POST"]}]}
+        wrapper = HTTPServerTestWrapper()
+        actor = wrapper.create_httpserver("http_server", routes_config=routes_config)
+        actor.pool.outbound.add("sample_service")
+        
+        actor.start()
+
+        #default add wrapper
+        data_obj = json.dumps([1,2,3])
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type": "application/json"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        headers, data = wrapper.get_response(event=event)
+        assert json_formatter(data) != json_formatter(data_obj)
+        assert json_formatter(data) == json_formatter(json.dumps({"data":[1,2,3]}))
+
+        data_obj = json.dumps({"temp": 213})
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type": "application/json"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        headers, data = wrapper.get_response(event=event)
+        assert json_formatter(data) != json_formatter(data_obj)
+        assert json_formatter(data) == json_formatter(json.dumps({"data":{"temp": 213}}))
+
+        data_obj = json.dumps({"temp": 213, "data": 123})
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type": "application/json"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        headers, data = wrapper.get_response(event=event)
+        assert json_formatter(data) != json_formatter(data_obj)
+        assert json_formatter(data) == json_formatter(json.dumps({"data":{"temp": 213, "data": 123}}))
+
+        #default ignore case
+        data_obj = json.dumps({"data": 213})
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type": "application/json"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        headers, data = wrapper.get_response(event=event)
+        assert json_formatter(data) == json_formatter(data_obj)
+        
+        #ignore wrapper variable
+        data_obj = json.dumps([1,2,3])
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type": "application/json"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        event = actor.pool.outbound["sample_service"].get(block=True)
+        event.set("use_response_wrapper", False)
+        headers, data = wrapper.get_response(event=event)
+        assert json_formatter(data) == json_formatter(data_obj)
+
+        actor.stop()
+
+    def test_wsgi_plugins(self):
+        '''
+            This is a test of the built in plugin functionality
+            Use this to help understand what a plugin should look like
+        '''
+        class TestPlugin1(object):
+            def __init__(self, actor, *args, **kwargs):
+                self.actor = actor
+            def apply(self, callback, route):
+                def callback_wrapper(*args, **kwargs):
+                    self.actor.test_plugin_1 = True
+                    return callback(*args, **kwargs)
+                return callback_wrapper
+        class TestPlugin2(object):
+            def __init__(self, actor, *args, **kwargs):
+                self.actor = actor
+            def apply(self, callback, route):
+                def callback_wrapper(*args, **kwargs):
+                    self.actor.test_plugin_2 = True
+                    return callback(*args, **kwargs)
+                return callback_wrapper
+
+        routes_config = {"routes":[{"id": "base","path": "/<queue:re:[a-zA-Z_0-9]+?>","method": ["POST"]}]}
+        wrapper = HTTPServerTestWrapper()
+        actor = wrapper.create_httpserver("http_server", routes_config=routes_config)
+        actor.pool.outbound.add("sample_service")
+        actor.test_plugin_1, actor.test_plugin_2 = False, False
+        actor.start()
+
+        data_obj = json.dumps({"data":123})
+        #pre install test
+        assert not actor.test_plugin_1 and not actor.test_plugin_2 == True
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type": "application/json"}, body=data_obj)
+        assert len(actor.pool.outbound["sample_service"]) == 1
+        assert not actor.test_plugin_1 and not actor.test_plugin_2 == True
+
+        #install plugins
+        actor.wsgi_app.install(TestPlugin1(actor=actor))
+        actor.wsgi_app.install(TestPlugin2(actor=actor))
+
+        #test after 1 submission
+        actor.test_plugin_1, actor.test_plugin_2 = False, False
+        assert not actor.test_plugin_1 and not actor.test_plugin_2 == True
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type": "application/json"}, body=data_obj)
+        assert actor.test_plugin_1 and actor.test_plugin_2 == True
+        
+        #test after 2 submissions
+        actor.test_plugin_1, actor.test_plugin_2 = False, False
+        assert not actor.test_plugin_1 and not actor.test_plugin_2 == True
+        wrapper.send_request(method="POST", path="/sample_service", headers={"Content-Type": "application/json"}, body=data_obj)
+        assert actor.test_plugin_1 and actor.test_plugin_2 == True
+        
+    def _test_manual(self):
+        routes_config = {"routes":[{"id": "base","path": "/<queue:re:[a-zA-Z_0-9]+?>","method": ["POST"]}]}
+        actor = HTTPServer("http_server", port=34567, address="0.0.0.0", routes_config=routes_config)
+        actor.pool.outbound.add("sample_service")
+        actor.start()
 
 
+        response = requests.post("http://localhost:34567/sample_service", headers={}, data="some text")
+        print response.text

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,10 +1,15 @@
 import unittest
+import json
+from lxml import etree
+from collections import OrderedDict, defaultdict
+from contextlib import contextmanager
 
 from collections import Mapping
 
-from compysition.errors import ResourceNotFound
+from compysition.errors import ResourceNotFound, InvalidEventDataModification
 from compysition.event import HttpEvent, Event, CompysitionException, XMLEvent, JSONEvent
 
+conversion_classes = [str, etree._Element, etree._ElementTree, etree._XSLTResultTree, dict, list, OrderedDict, None.__class__]
 
 class TestEvent(unittest.TestCase):
     def setUp(self):
@@ -152,3 +157,306 @@ class TestHttpEvent(unittest.TestCase):
         # The type changed from int to str but that's not really avoidable
         assert json_event.data['candy'][0]['apple'] == '2'
         assert json_event.data['candy'][1]['grape'] == '3'
+
+
+parser = etree.XMLParser(remove_blank_text=True)
+#used to ignore spacing differences and look at basic XML structure
+def xml_formatter(xml_str):
+    return etree.tostring(etree.XML(xml_str, parser=parser))
+
+#used to ignore spacing differences and look at basic JSON structure
+def json_formatter(json_str):
+    return json.dumps(json.loads(json_str))
+
+
+@contextmanager
+def throws_excpetion(*exceptions):
+    exceptions = (Exception) if len(exceptions) == 0 else exceptions
+    try:
+        yield
+        assert False
+    except exceptions:
+        pass
+
+class TestXMLEvent(unittest.TestCase):
+
+    def test_conversion_classes(self):
+        current_conversion_classes = XMLEvent().conversion_methods.keys()
+        assert len(current_conversion_classes) == len(conversion_classes)
+        for cur_conv_meth in current_conversion_classes:
+            assert cur_conv_meth in conversion_classes
+
+    def test_json_conversion_methods(self):
+        src = {"my_data":123}
+        event = XMLEvent(data=src)
+        assert event.data_string() == xml_formatter("<my_data>123</my_data>")
+    
+        src = {"my_data":{"lvl1":[1,2,3]}}
+        event = XMLEvent(data=src)
+        assert event.data_string() == xml_formatter("<my_data><lvl1>1</lvl1><lvl1>2</lvl1><lvl1>3</lvl1></my_data>")
+        
+        src = {"my_data":{"lvl1":1}}
+        event = XMLEvent(data=src)
+        assert event.data_string() == xml_formatter("<my_data><lvl1>1</lvl1></my_data>")
+
+        src = {"my_data":{"lvl1":1, "@my_attr": "type"}}
+        event = XMLEvent(data=src)
+        assert event.data_string() == xml_formatter("<my_data my_attr='type'><lvl1>1</lvl1></my_data>")
+
+        src = {"lvl1":[1,2,3]}
+        event = XMLEvent(data=src)
+        assert event.data_string() == xml_formatter("<jsonified_envelope><lvl1>1</lvl1><lvl1>2</lvl1><lvl1>3</lvl1></jsonified_envelope>")
+
+        src = [1,2,3]
+        event = XMLEvent(data=src)
+        assert event.data_string() == xml_formatter("<jsonified_envelope><jsonified_envelope>1</jsonified_envelope><jsonified_envelope>2</jsonified_envelope><jsonified_envelope>3</jsonified_envelope></jsonified_envelope>")
+
+        src = {}
+        with throws_excpetion(InvalidEventDataModification):
+            event = XMLEvent(data=src)
+        #ATTENTION
+        # I think this should be true instead
+        #assert event.data_string() == xml_formatter("<jsonified_envelope/>")
+
+    def test_str_conversion_methods(self):
+        src = "<my_data my_attr='type'>123</my_data>"
+        event = XMLEvent(data=src)
+        assert event.data_string() == xml_formatter("<my_data my_attr='type'>123</my_data>")
+
+        src = ""
+        with throws_excpetion(InvalidEventDataModification):
+            event = XMLEvent(data=src)
+        #ATTENTION
+        # I think this should be true instead
+        #assert event.data_string() == xml_formatter("<data/>")
+    
+        src = json_formatter('{"test":"ok"}')
+        with throws_excpetion(InvalidEventDataModification):
+            event = XMLEvent(data=src)
+
+        src = "some random text"
+        with throws_excpetion(InvalidEventDataModification):
+            event = XMLEvent(data=src)
+
+        src = "<element><invalid_xml></element>"
+        with throws_excpetion(InvalidEventDataModification):
+            event = XMLEvent(data=src)
+
+        src = "<element>"
+        with throws_excpetion(InvalidEventDataModification):
+            event = XMLEvent(data=src)
+
+    def test_none_conversion_methods(self):
+        src = None
+        event = XMLEvent(data=src)
+        assert event.data_string() == xml_formatter("<root/>")
+        #ATTENTION
+        # I think one of these should be true instead
+        #assert event.data_string() == xml_formatter("<data/>")
+
+    def test_xml_conversion_methods(self):
+        src = etree.fromstring(xml_formatter("<my_data my_attr='type'>123</my_data>"))
+        event = XMLEvent(data=src)
+        assert event.data_string() == xml_formatter("<my_data my_attr='type'>123</my_data>")
+    
+    def test_error_string(self):
+        event = XMLEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong")
+        assert xml_formatter(event.error_string()) == xml_formatter("<errors><error><message>Oops Something Went Wrong</message></error></errors>")
+        
+        event = XMLEvent()
+        event.error = InvalidEventDataModification(message=["Oops Something Went Wrong", "Oops Something Else Went Wrong Too"])
+        assert xml_formatter(event.error_string()) == xml_formatter("<errors><error><message>Oops Something Went Wrong</message></error><error><message>Oops Something Else Went Wrong Too</message></error></errors>")
+
+        event = XMLEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code="555")
+        assert xml_formatter(event.error_string()) == xml_formatter("<errors><error><message>Oops Something Went Wrong</message><code>555</code></error></errors>")
+
+        event = XMLEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code=555)
+        with throws_excpetion(TypeError):
+            event.error_string()
+        #ATTENTION
+        # I don't think this should throw and error
+        # Instead I think this should be true
+        #assert xml_formatter(event.error_string()) == xml_formatter("<errors><error><message>Oops Something Went Wrong</message><code>555</code></error></errors>")
+
+        event = XMLEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code="555", override="123")
+        assert event.error_string() == "123"
+
+        src = xml_formatter("<my_data my_attr='type'>123</my_data>")
+        event = XMLEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code="555", override=src)
+        assert xml_formatter(event.error_string()) == xml_formatter("<my_data my_attr='type'>123</my_data>")
+        
+        src = etree.fromstring(xml_formatter("<my_data my_attr='type'>123</my_data>"))
+        event = XMLEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code="555", override=src)
+        assert xml_formatter(event.error_string()) == xml_formatter("<errors><error><message>Oops Something Went Wrong</message><code>555</code></error></errors>")
+        #ATTENTION
+        # I think this should be true instead
+        #assert xml_formatter(event.error_string()) == xml_formatter("<my_data my_attr='type'>123</my_data>")
+
+        src = {"my_data":{"lvl1":1, "@my_attr": "type"}}
+        event = XMLEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code="555", override=src)
+        assert event.error_string() == {"my_data":{"lvl1":1, "@my_attr": "type"}}
+        #ATTENTION
+        # I think this should be a string vs a json object
+        #assert json_formatter(event.error_string()) == json_formatter("<my_data my_attr='type'>123</my_data>")
+
+
+class TestJSONEvent(unittest.TestCase):
+
+    def test_conversion_classes(self):
+        current_conversion_classes = JSONEvent().conversion_methods.keys()
+        assert len(current_conversion_classes) == len(conversion_classes)
+        for cur_conv_meth in current_conversion_classes:
+            assert cur_conv_meth in conversion_classes
+
+    def test_json_conversion_methods(self):
+        src = {"test":"ok"}
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({"test":"ok"}))
+
+        src = {"test":"ok","test2":1234}
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({"test":"ok","test2":1234}))
+
+        src = {"test":{"ok":"data"},"test2":[1,2,3,4]}
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({"test":{"ok":"data"},"test2":[1,2,3,4]}))
+
+        src = [1,2,3,4]
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps([1,2,3,4]))
+
+        src = {}
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({}))
+
+    def test_xml_conversion_methods(self):
+        '''
+            Not implemented but a way to translate numbers would be nice
+        '''
+        
+        src = etree.fromstring("<my_data>123</my_data>")
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({"my_data":"123"}))
+
+        src = etree.fromstring("<my_data><lvl1>1</lvl1><lvl1>2</lvl1><lvl1>3</lvl1></my_data>")
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({"my_data":{"lvl1":["1","2","3"]}}))
+
+        src = etree.fromstring("<my_data><lvl1>1</lvl1></my_data>")
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({"my_data":{"lvl1":"1"}}))
+
+        src = etree.fromstring("<my_data my_attr='type'><lvl1>1</lvl1></my_data>")
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({"my_data":{"lvl1":"1", "@my_attr": "type"}}))
+
+        src = etree.fromstring("<jsonified_envelope><lvl1>1</lvl1><lvl1>2</lvl1><lvl1>3</lvl1></jsonified_envelope>")
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({"lvl1":["1","2","3"]}))
+
+        src = etree.fromstring("<jsonified_envelope><jsonified_envelope>1</jsonified_envelope><jsonified_envelope>2</jsonified_envelope><jsonified_envelope>3</jsonified_envelope></jsonified_envelope>")
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({"jsonified_envelope":["1","2","3"]}))
+        #ATTENTION
+        # I think this should be true instead to reverse the functionality of XMLEvent conversion
+        #assert event.data_string() == json_formatter(json.dumps(["1","2","3"]))
+
+        src = etree.fromstring("<jsonified_envelope/>")
+        event = JSONEvent(data=src)
+        assert event.data_string() == 'null'
+        #ATTENTION
+        # I think one of these should be true instead (preferably the first)
+        #assert event.data_string() == json_formatter(json.dumps({}))
+        #assert event.data_string() == None
+
+        src = etree.fromstring("<my_data force_list=''>123</my_data>")
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({"my_data":[{"#text":"123"}]}))
+        #ATTENTION
+        # I feel like this would be more usable
+        #assert event.data_string() == json_formatter(json.dumps({"my_data":["123"]}))
+        
+        src = etree.fromstring("<my_data force_list=''><level1>123</level1></my_data>")
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({"my_data":[{"level1":"123"}]}))
+        
+    def test_str_conversion_methods(self):
+        src = json.dumps({"my_data":"ok"})
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({"my_data":"ok"}))
+
+        src = ""
+        with throws_excpetion(InvalidEventDataModification):
+            event = JSONEvent(data=src)
+        #ATTENTION
+        # I think this should be true instead
+        #assert event.data_string() == json_formatter(json.dumps({}))
+
+        src = "some random text"
+        with throws_excpetion(InvalidEventDataModification):
+            event = JSONEvent(data=src)
+
+        src = "<some_xml/>"
+        with throws_excpetion(InvalidEventDataModification):
+            event = JSONEvent(data=src)
+
+        src = '{"invalid: "json"}'
+        with throws_excpetion(InvalidEventDataModification):
+            event = JSONEvent(data=src)
+
+    def test_none_conversion_methods(self):
+        src = None
+        event = JSONEvent(data=src)
+        assert event.data_string() == json_formatter(json.dumps({}))
+
+    def test_error_string(self):
+        event = JSONEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong")
+        assert json_formatter(event.error_string()) == json_formatter(json.dumps([{"override":None, "message":"Oops Something Went Wrong", "code": None}]))
+        #ATTENTION
+        # Probably don't need to return "override" data or null code data        
+
+        event = JSONEvent()
+        event.error = InvalidEventDataModification(message=["Oops Something Went Wrong", "Oops Something Else Went Wrong Too"])
+        assert json_formatter(event.error_string()) == json_formatter(json.dumps([{"override":None, "message":"Oops Something Went Wrong", "code": None}, {"override":None, "message":"Oops Something Else Went Wrong Too", "code": None}]))
+
+        event = JSONEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code=555)
+        assert json_formatter(event.error_string()) == json_formatter(json.dumps([{"override":None, "message":"Oops Something Went Wrong", "code": 555}]))
+        
+        event = JSONEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code="555")
+        assert json_formatter(event.error_string()) == json_formatter(json.dumps([{"override":None, "message":"Oops Something Went Wrong", "code": "555"}]))
+        
+        event = JSONEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code="555", override="123")
+        assert event.error_string() == '"123"'
+        #ATTENTION
+        # This seems odd probably should be without the added quotes
+        #assert event.error_string() == '123'
+
+        src = json_formatter(json.dumps({"my_data":123}))
+        event = JSONEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code="555", override=src)
+        assert json_formatter(event.error_string()) == '"{\\\"my_data\\\": 123}"'
+        #ATTENTION
+        # This seems odd probably should be without the added quotes
+        #assert json_formatter(event.error_string()) == json_formatter(json.dumps({"my_data":123}))
+        
+        src = {"my_data":123}
+        event = JSONEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code="555", override=src)
+        assert json_formatter(event.error_string()) == json_formatter(json.dumps({"my_data":123}))
+        
+        src = etree.fromstring(xml_formatter("<my_data my_attr='type'>123</my_data>"))
+        event = JSONEvent()
+        event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code="555", override=src)
+        with throws_excpetion(TypeError):
+            json_formatter(event.error_string())

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,10 +1,7 @@
 import unittest
 import json
 from lxml import etree
-from collections import OrderedDict, defaultdict
-from contextlib import contextmanager
-
-from collections import Mapping
+from collections import OrderedDict, Mapping
 
 from compysition.errors import ResourceNotFound, InvalidEventDataModification
 from compysition.event import HttpEvent, Event, CompysitionException, XMLEvent, JSONEvent
@@ -17,7 +14,6 @@ class TestEvent(unittest.TestCase):
 
     def test_distinct_meta_and_event_ids(self):
         self.assertNotEqual(self.event.event_id, self.event.meta_id)
-
 
 class TestHttpEvent(unittest.TestCase):
     def test_default_status(self):
@@ -168,16 +164,6 @@ def xml_formatter(xml_str):
 def json_formatter(json_str):
     return json.dumps(json.loads(json_str))
 
-
-@contextmanager
-def throws_excpetion(*exceptions):
-    exceptions = (Exception) if len(exceptions) == 0 else exceptions
-    try:
-        yield
-        assert False
-    except exceptions:
-        pass
-
 class TestXMLEvent(unittest.TestCase):
 
     def test_conversion_classes(self):
@@ -212,7 +198,7 @@ class TestXMLEvent(unittest.TestCase):
         assert event.data_string() == xml_formatter("<jsonified_envelope><jsonified_envelope>1</jsonified_envelope><jsonified_envelope>2</jsonified_envelope><jsonified_envelope>3</jsonified_envelope></jsonified_envelope>")
 
         src = {}
-        with throws_excpetion(InvalidEventDataModification):
+        with self.assertRaises(InvalidEventDataModification):
             event = XMLEvent(data=src)
         #ATTENTION
         # I think this should be true instead
@@ -224,26 +210,26 @@ class TestXMLEvent(unittest.TestCase):
         assert event.data_string() == xml_formatter("<my_data my_attr='type'>123</my_data>")
 
         src = ""
-        with throws_excpetion(InvalidEventDataModification):
+        with self.assertRaises(InvalidEventDataModification):
             event = XMLEvent(data=src)
         #ATTENTION
         # I think this should be true instead
         #assert event.data_string() == xml_formatter("<data/>")
     
         src = json_formatter('{"test":"ok"}')
-        with throws_excpetion(InvalidEventDataModification):
+        with self.assertRaises(InvalidEventDataModification):
             event = XMLEvent(data=src)
 
         src = "some random text"
-        with throws_excpetion(InvalidEventDataModification):
+        with self.assertRaises(InvalidEventDataModification):
             event = XMLEvent(data=src)
 
         src = "<element><invalid_xml></element>"
-        with throws_excpetion(InvalidEventDataModification):
+        with self.assertRaises(InvalidEventDataModification):
             event = XMLEvent(data=src)
 
         src = "<element>"
-        with throws_excpetion(InvalidEventDataModification):
+        with self.assertRaises(InvalidEventDataModification):
             event = XMLEvent(data=src)
 
     def test_none_conversion_methods(self):
@@ -274,7 +260,7 @@ class TestXMLEvent(unittest.TestCase):
 
         event = XMLEvent()
         event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code=555)
-        with throws_excpetion(TypeError):
+        with self.assertRaises(TypeError):
             event.error_string()
         #ATTENTION
         # I don't think this should throw and error
@@ -393,22 +379,22 @@ class TestJSONEvent(unittest.TestCase):
         assert event.data_string() == json_formatter(json.dumps({"my_data":"ok"}))
 
         src = ""
-        with throws_excpetion(InvalidEventDataModification):
+        with self.assertRaises(InvalidEventDataModification):
             event = JSONEvent(data=src)
         #ATTENTION
         # I think this should be true instead
         #assert event.data_string() == json_formatter(json.dumps({}))
 
         src = "some random text"
-        with throws_excpetion(InvalidEventDataModification):
+        with self.assertRaises(InvalidEventDataModification):
             event = JSONEvent(data=src)
 
         src = "<some_xml/>"
-        with throws_excpetion(InvalidEventDataModification):
+        with self.assertRaises(InvalidEventDataModification):
             event = JSONEvent(data=src)
 
         src = '{"invalid: "json"}'
-        with throws_excpetion(InvalidEventDataModification):
+        with self.assertRaises(InvalidEventDataModification):
             event = JSONEvent(data=src)
 
     def test_none_conversion_methods(self):
@@ -458,5 +444,5 @@ class TestJSONEvent(unittest.TestCase):
         src = etree.fromstring(xml_formatter("<my_data my_attr='type'>123</my_data>"))
         event = JSONEvent()
         event.error = InvalidEventDataModification(message="Oops Something Went Wrong", code="555", override=src)
-        with throws_excpetion(TypeError):
+        with self.assertRaises(TypeError):
             json_formatter(event.error_string())


### PR DESCRIPTION
- Removed unused dependency bs4
- Refined pytest installation
- Defined some dependency versions
- Modified HTTPServer slightly to make it more mock-able for unit tests
- Added unit tests for HTTPServer and various Event conversion methods
- Identified several items denoted by #ATTENTION throughout tests
     - The largest concerns the HTTPServer ContentTypePlugin which is not a decorator as expect.  The current implementation only applies to the first HTTP request processed by HTTPServer.
     - Others include several event conversion scenarios that I believe are either unintended or could be improved