### PR TITLE
added __slots__ to events; improved pickling functionalities

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -3,3 +3,10 @@ Compysition changelog
 
 Version
 1.3.0
+
+- Adjusted pickling techniques to improve performance.
+    - Now utilizes highest pickle protocol in mpdactor functions.
+    - event cloning now utilizes direct pickling vs deepcopy
+    - actor-actor event passing now uses new event xclone function which utilizes locally stored raw pickle data and iteration to increase performance
+- Added __slots__ to various event types to decrease memory footprint.
+    - Adjusted event pickling functions to accomodate __slots__ and keep event dynamicness.

--- a/compysition/__init__.py
+++ b/compysition/__init__.py
@@ -27,9 +27,12 @@ from .queue import QueuePool
 from .logger import Logger
 from .director import Director
 from .event import Event
+from .util import set_warning_filter
 
 from gevent import monkey
 monkey.patch_all()
 
 __version__ = '1.3.0'
 version = __version__
+
+set_warning_filter()

--- a/compysition/actor.py
+++ b/compysition/actor.py
@@ -240,7 +240,7 @@ class Actor(with_metaclass(abc.ABCMeta, object)):
 
     def _send_all(self, queues, event):
         try:
-            iterator = queues.itervalues()
+            iterator = itervalues(queues)
         except AttributeError:
             iterator = queues
         for clone, queue in event.xclone(iterator):

--- a/compysition/actor.py
+++ b/compysition/actor.py
@@ -94,7 +94,6 @@ class Actor(object):
         self.__blocking_consume = blocking_consume
         self.rescue = rescue
         self.max_rescue = max_rescue
-
         self.convert_output = convert_output
 
     def _clear_all(self):
@@ -236,13 +235,16 @@ class Actor(object):
                     raise_error = True
             if raise_error:
                 raise InvalidActorOutput("Event was of type '{_type}', expected '{output}'".format(_type=type(event), output=self.output))
+        
+        self._send_all(queues=queues, event=event)
 
+    def _send_all(self, queues, event):
         try:
-            for queue in queues.itervalues():
-                self._send(queue, deepcopy(event))
+            iterator = queues.itervalues()
         except AttributeError:
-            for queue in queues:
-                self._send(queue, deepcopy(event))
+            iterator = queues
+        for clone, queue in event.xclone(iterator):
+            self._send(queue, clone)
 
     def _send(self, queue, event):
         queue.put(event)

--- a/compysition/actors/mdpactors.py
+++ b/compysition/actors/mdpactors.py
@@ -175,7 +175,7 @@ class MDPClient(MDPActor):
             request_id = event.meta_id                  # Set for broker logging so we can trace the path of an event easily
             service = b"{0}".format(self.service_prefix + event.service + self.service_postfix)
             self.logger.info("Sending event to service '{0}'".format(service), event=event)
-            message = [request_id, b"{0}".format(pickle.dumps(event))]
+            message = [request_id, b"{0}".format(pickle.dumps(event, -1))]
             self.send(service, message, broker_socket=socket)
         except Exception as err:
             self.logger.error("Unable to find necessary chains: {0}".format(traceback.format_exc()))
@@ -291,7 +291,7 @@ class MDPWorker(MDPActor):
             return_address = request.return_address
             broker_event_logging_id = event.meta_id
             try:
-                message = ['', MDPDefinition.W_WORKER, MDPDefinition.W_REPLY, return_address, '', str(broker_event_logging_id), b"{0}".format(pickle.dumps(event))]
+                message = ['', MDPDefinition.W_WORKER, MDPDefinition.W_REPLY, return_address, '', str(broker_event_logging_id), b"{0}".format(pickle.dumps(event, -1))]
             except Exception as err:
                 self.logger.error(err, event=event)
 

--- a/compysition/event.py
+++ b/compysition/event.py
@@ -24,7 +24,6 @@ import json
 import traceback
 import re
 import xmltodict
-import cPickle as pickle
 import urllib
 import warnings
 import functools
@@ -44,8 +43,10 @@ from .util.event import (_InternalJSONXMLConverter, _decimal_default, _NullLooku
 
 if PY2:
     import urllib
+    import cPickle as pickle
 else:
     import urllib.parse as urllib
+    import pickle
 
 """
 Compysition event is created and passed by reference among actors
@@ -198,7 +199,7 @@ class Event(object):
         return props
 
     def update_properties(self, **kwargs):
-        for k, v in kwargs.iteritems():
+        for k, v in iteritems(kwargs):
             setattr(self, k, v)
 
     @property

--- a/compysition/testutils/__init__.py
+++ b/compysition/testutils/__init__.py
@@ -1,0 +1,23 @@
+import random
+import sys
+from types import ModuleType, FunctionType
+from gc import get_referents
+
+def gen_rdm_attr_name(length):
+    letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_"
+    return "".join([random.choice(letters) for i in range(length)])
+
+def getsize(obj):
+    BLACKLIST = type, ModuleType, FunctionType
+    if isinstance(obj, BLACKLIST):
+        raise TypeError('getsize() does not take argument of type: '+ str(type(obj)))
+    seen_ids, size, objects = set(), 0, [obj]
+    while objects:
+        need_referents = []
+        for obj in objects:
+            if not isinstance(obj, BLACKLIST) and id(obj) not in seen_ids:
+                seen_ids.add(id(obj))
+                size += sys.getsizeof(obj)
+                need_referents.append(obj)
+        objects = get_referents(*need_referents)
+    return size

--- a/compysition/testutils/event_old.py
+++ b/compysition/testutils/event_old.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  default.py
+#
+#  Copyright 2014 Adam Fiebig <fiebig.adam@gmail.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+import json
+import traceback
+import re
+import xmltodict
+
+from uuid import uuid4 as uuid
+from lxml import etree
+from copy import deepcopy
+from datetime import datetime
+from decimal import Decimal
+from collections import OrderedDict, defaultdict
+
+from compysition.errors import (ResourceNotModified, MalformedEventData, InvalidEventDataModification, UnauthorizedEvent,
+    ForbiddenEvent, ResourceNotFound, EventCommandNotAllowed, ActorTimeout, ResourceConflict, ResourceGone,
+    UnprocessableEventData, EventRateExceeded, CompysitionException, ServiceUnavailable)
+from compysition.util import ignore
+from compysition.util.event import (_InternalJSONXMLConverter, _decimal_default, _NullLookupValue, 
+    _UnescapedDictXMLGenerator)
+
+"""
+Compysition event is created and passed by reference among actors
+"""
+
+NoneType = type(None)
+DEFAULT_EVENT_SERVICE = "default"
+DEFAULT = object()
+
+setattr(xmltodict, "XMLGenerator", _UnescapedDictXMLGenerator)
+_XML_TYPES = [etree._Element, etree._ElementTree, etree._XSLTResultTree]
+_JSON_TYPES = [dict, list, OrderedDict]
+
+class DataFormatInterface(object):
+    """
+    Interface used as an identifier for data format classes. Used during event type conversion
+    To create a new datatype, simply implement this interface on the newly created class
+    """
+    pass
+
+class Event(object):
+
+    """
+    Anatomy of an event:
+        - event_id: The unique and functionally immutable ID for this new event
+        - meta_id:  The ID associated with other unique event data flows. This ID is used in logging
+        - service:  (default: default) Used for compatability with the ZeroMQ MajorDomo configuration. Scope this to specific types of interprocess routing
+        - data:     <The data passed and worked on from event to event. Mutable and variable>
+        - kwargs:   All other kwargs passed upon Event instantiation will be added to the event dictionary
+
+    """
+
+    _content_type = "text/plain"
+
+    def __init__(self, meta_id=None, service=None, data=None, *args, **kwargs):
+        self.event_id = uuid().get_hex()
+        self.meta_id = meta_id if meta_id else self.event_id
+        self.service = service or DEFAULT_EVENT_SERVICE
+        self.data = data
+        self.error = None
+        self.created = datetime.now()
+        self.__dict__.update(kwargs)
+
+    def set(self, key, value):
+        with ignore(AttributeError, TypeError, ValueError):
+            setattr(self, key, value)
+            return True
+        return False
+
+    def get(self, key, default=DEFAULT):
+        val = getattr(self, key, default)
+        if val is DEFAULT:
+            raise AttributeError("Event property '{property}' does not exist".format(property=key))
+        return val
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, data):
+        self._data = self._convert_data(data=data)
+
+    def _convert_data(self, data):
+        try:
+            return self.conversion_methods[data.__class__](data)
+        except KeyError as e:
+            raise InvalidEventDataModification("Data of type '{_type}' was not valid for event type {cls}: {err}".format(_type=type(data),
+                                                                                          cls=self.__class__, err=traceback.format_exc()))
+        except ValueError as err:
+            raise InvalidEventDataModification("Malformed data: {err}".format(err=err))
+        except Exception as err:
+            raise InvalidEventDataModification("Unknown error occurred on modification: {err}".format(err=err))
+
+    @property
+    def event_id(self):
+        return self._event_id
+
+    @event_id.setter
+    def event_id(self, event_id):
+        if self.get("_event_id", None):
+            raise InvalidEventDataModification("Cannot alter event_id once it has been set. A new event must be created")
+        self._event_id = event_id
+
+    def _list_get(self, obj, key, default):
+        with ignore(ValueError, IndexError, TypeError, KeyError, AttributeError):
+            return obj[int(key)]
+        return default
+
+    def _getattr(self, obj, key, default):
+        with ignore(TypeError):
+            return getattr(obj, key, default)
+        return default
+
+    def _obj_get(self, obj, key, default):
+        with ignore(TypeError, AttributeError):
+            return obj.get(key, default)
+        return default
+
+    def lookup(self, path):
+        """
+        Implements the retrieval of a single list index through an integer path entry
+        """
+        if isinstance(path, str):
+            path = [path]
+
+        value = reduce(lambda obj, key: self._obj_get(obj, key, self._getattr(obj, key, self._list_get(obj, key, _NullLookupValue()))), [self] + path)
+        if isinstance(value, _NullLookupValue):
+            return None
+        return value
+
+    def get_properties(self):
+        """
+        Gets a dictionary of all event properties except for event.data
+        Useful when event data is too large to copy in a performant manner
+        """
+        return {k: v for k, v in self.__dict__.iteritems() if k != "data" and k != "_data"}
+
+    def __getstate__(self):
+        return dict(self.__dict__)
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self.data = state['_data']
+        self.error = state.get('_error', None)
+
+    def __str__(self):
+        return str(self.__getstate__())
+
+    @property
+    def error(self):
+        return self._error
+
+    @error.setter
+    def error(self, exception):
+        self._set_error(exception)
+
+    def _set_error(self, exception):
+        self._error = exception
+
+    conversion_methods = defaultdict(lambda: lambda data: data)
+
+    def format_error(self):
+        if self.error:
+            if hasattr(self.error, 'override') and self.error.override:
+                return self.error.override
+            messages = self.error.message
+            if not isinstance(messages, list):
+                messages = [messages]
+            errors = map(lambda _error:
+                        dict(message=str(getattr(_error, "message", _error)), **self.error.__dict__),
+                        messages)
+            return errors
+        return None
+
+    def error_string(self):
+        return None if self.error is None else str(self.format_error())
+
+    def data_string(self):
+        return str(self.data)
+
+    def convert(self, convert_to):
+        if issubclass(convert_to, self.__class__):
+            # Widening conversion
+            new_class = convert_to
+        else:
+            if not issubclass(self.__class__, convert_to):
+                # A complex widening conversion
+                bases = tuple([convert_to] + filter(lambda cls: not issubclass(cls, DataFormatInterface) and not issubclass(convert_to, cls), list(self.__class__.__bases__) + [self.__class__]))
+                if len(bases) == 1:
+                    new_class = bases[0]
+                else:
+                    new_class = filter(lambda cls: cls.__bases__ == bases, built_classes)[0]
+            else:
+                # This is an attempted narrowing conversion
+                raise InvalidEventConversion("Narrowing event conversion attempted, this is not allowed <Attempted {old} -> {new}>".format(
+                        old=self.__class__, new=convert_to))
+
+        new_class = new_class.__new__(new_class)
+        new_class.__dict__.update(self.__dict__)
+        new_class.data = self.data
+        return new_class
+
+    def clone(self):
+        return deepcopy(self)
+
+
+class HttpEvent(Event):
+
+    content_type = "text/plain"
+
+    def __init__(self, headers=None, status=(200, "OK"), environment={}, pagination=None, *args, **kwargs):
+        self.headers = headers or {}
+        self.method = environment.get('REQUEST_METHOD', None)
+        self.status = status
+        self.environment = environment
+        self._pagination = pagination
+        super(HttpEvent, self).__init__(*args, **kwargs)
+
+    @property
+    def status(self):
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        if isinstance(status, tuple):
+            self._status = status
+        elif isinstance(status, str):
+            status = re.split(' |-', status, 1)
+            if len(status) == 2:
+                self._status = (int(status[0]), status[1])
+
+    def _set_error(self, exception):
+        if isinstance(exception, Exception):
+            error_state = http_code_map[exception.__class__]
+            self.status = error_state.get("status")
+            self.headers.update(error_state.get("headers", {}))
+
+        super(HttpEvent, self)._set_error(exception)
+
+    @property
+    def pagination(self):
+        return self._pagination
+
+    @pagination.setter
+    def pagination(self, pagination_dict):
+        if 'limit' in pagination_dict and 'offset' in pagination_dict:
+            self._pagination = pagination_dict
+        else:
+            raise ValueError('Must have limit and offset keys set in pagination_dict')
+
+class _XMLFormatInterface(DataFormatInterface):
+
+    content_type = "application/xml"
+    _default_tab_string = "<root/>"
+
+    conversion_methods = {str: lambda data: _XMLFormatInterface._from_string(data)}
+    conversion_methods.update(dict.fromkeys(_XML_TYPES, lambda data: data))
+    conversion_methods.update(dict.fromkeys(_JSON_TYPES, lambda data: _InternalJSONXMLConverter.to_xml(data)))
+    conversion_methods.update({None.__class__: lambda data: _XMLFormatInterface._from_string(data)})
+
+    @staticmethod
+    def _from_string(data):
+        ####### Desired
+        #if data is None or len(data) == 0:
+        ####### Current
+        if data is None:
+        #######
+            return etree.fromstring(_XMLFormatInterface._default_tab_string)
+        return etree.fromstring(data)
+
+    def __getstate__(self):
+        state = super(_XMLFormatInterface, self).__getstate__()
+        state['_data'] = etree.tostring(self.data)
+        return state
+
+    def data_string(self):
+        return etree.tostring(self.data)
+
+    def format_error(self):
+        errors = super(_XMLFormatInterface, self).format_error()
+        if self.error and self.error.override:
+            try:
+                return etree.fromstring(errors)
+            except (ValueError, etree.XMLSyntaxError):
+                return errors
+        elif errors:
+            result = etree.Element("errors")
+            for error in errors:
+                error_element = etree.Element("error")
+                message_element = etree.Element("message")
+                code_element = etree.Element("code")
+                error_element.append(message_element)
+                message_element.text = error['message']
+                if getattr(error, 'code', None) or ('code' in error and error['code']):
+                    code_element.text = error['code']
+                    error_element.append(code_element)
+                result.append(error_element)
+        return result
+
+    def error_string(self):
+        error = self.format_error()
+        if error is not None:
+            with ignore(TypeError):
+                return etree.tostring(error)
+        return error
+
+class _JSONFormatInterface(DataFormatInterface):
+
+    content_type = "application/json"
+
+    conversion_methods = {str: lambda data: _JSONFormatInterface._from_string(data)}
+    conversion_methods.update(dict.fromkeys(_JSON_TYPES, lambda data: json.loads(json.dumps(data, default=_decimal_default))))
+    conversion_methods.update(dict.fromkeys(_XML_TYPES, lambda data: _InternalJSONXMLConverter.to_json(data)))
+    conversion_methods.update({None.__class__: lambda data: _JSONFormatInterface._from_string(data)})
+
+    @staticmethod
+    def _from_string(data):
+        ####### Desired
+        #return {} if data is None or len(data) == 0 else json.loads(data)
+        ####### Current
+        return {} if data is None else json.loads(data)
+        #######
+
+    def __getstate__(self):
+        state = super(_JSONFormatInterface, self).__getstate__()
+        state['_data'] = json.dumps(self.data)
+        return state
+
+    def data_string(self):
+        return json.dumps(self.data, default=_decimal_default)
+
+    def error_string(self):
+        error = self.format_error()
+        if error is not None:
+            with ignore(TypeError):
+                return json.dumps(error)
+        return error
+
+class XMLEvent(_XMLFormatInterface, Event): pass
+class JSONEvent(_JSONFormatInterface, Event): pass
+
+class JSONHttpEvent(JSONEvent, HttpEvent): pass
+class XMLHttpEvent(XMLEvent, HttpEvent): pass
+
+class LogEvent(Event):
+    """
+    This is a lightweight event designed to mimic some of the event properties of a regular event
+    """
+
+    def __init__(self, level, origin_actor, message, id=None):
+        self.id = id
+        self.event_id = uuid().get_hex()
+        self.meta_id = id or self.event_id
+        self.level = level
+        self.time = datetime.now().strftime('%Y-%m-%d %H:%M:%S,%f')[:-3]
+        self.origin_actor = origin_actor
+        self.message = message
+        self.data = {"id":              self.id,
+                    "level":            self.level,
+                    "time":             self.time,
+                    "origin_actor":     self.origin_actor,
+                    "message":          self.message}
+
+built_classes = [Event, XMLEvent, JSONEvent, HttpEvent, JSONHttpEvent, XMLHttpEvent, LogEvent]
+__all__ = map(lambda cls: cls.__name__, built_classes)
+
+http_code_map = defaultdict(lambda: {"status": ((500, "Internal Server Error"))},
+                            {
+                                ResourceNotModified:    {"status": (304, "Not Modified")},
+                                MalformedEventData:     {"status": (400, "Bad Request")},
+                                InvalidEventDataModification: {"status": (400, "Bad Request")},
+                                UnauthorizedEvent:      {"status": (401, "Unauthorized"),
+                                                         "headers": {'WWW-Authenticate': 'Basic realm="Compysition Server"'}},
+                                ForbiddenEvent:         {"status": (403, "Forbidden")},
+                                ResourceNotFound:       {"status": (404, "Not Found")},
+                                EventCommandNotAllowed: {"status": (405, "Method Not Allowed")},
+                                ActorTimeout:           {"status": (408, "Request Timeout")},
+                                ResourceConflict:       {"status": (409, "Conflict")},
+                                ResourceGone:           {"status": (410, "Gone")},
+                                UnprocessableEventData: {"status": (422, "Unprocessable Entity")},
+                                EventRateExceeded:      {"status": (429, "Too Many Requests")},
+                                CompysitionException:   {"status": (500, "Internal Server Error")},
+                                ServiceUnavailable:     {"status": (503, "Service Unavailable")},
+                                NoneType:               {"status": (200, "OK")}         # Clear an error
+                            })
+
+__all__.append(http_code_map)

--- a/compysition/util/__init__.py
+++ b/compysition/util/__init__.py
@@ -1,3 +1,4 @@
+import warnings
 from contextlib import contextmanager
 
 @contextmanager
@@ -6,3 +7,17 @@ def ignore(*exceptions):
 		yield
 	except exceptions:
 		pass
+
+_default_warning_filter = 'always'
+
+def set_warning_filter():
+    warnings.simplefilter(_default_warning_filter, DeprecationWarning)
+    warnings.simplefilter(_default_warning_filter, PendingDeprecationWarning)
+
+@contextmanager
+def suppress_deprecation():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    warnings.simplefilter("ignore", PendingDeprecationWarning)
+    yield
+    warnings.simplefilter(_default_warning_filter, DeprecationWarning)
+    warnings.simplefilter(_default_warning_filter, PendingDeprecationWarning)

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -893,7 +893,7 @@ class TestActor(unittest.TestCase):
         queue_names = ["a", "b", "c", "d", "e"]
         queues = [Queue(name) for name in queue_names]
         queue_map = dict(zip(queue_names, queues))
-        print("1")
+        print("")
         print("old vs new", 
             self._time_send_all(actor=old_actor, queues=queues, event=event), 
             self._time_send_all(actor=actor, queues=queues, event=event)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from lxml import etree
 from collections import OrderedDict, Mapping
 import urllib
+import pytest
 
 from compysition.errors import ResourceNotFound, InvalidEventDataModification
 from compysition.event import (HttpEvent, Event, CompysitionException, XMLEvent, 
@@ -109,7 +110,7 @@ class TestEvent(unittest.TestCase):
         print("e2 vs e5", getsize(e2), getsize(e5))
         print("e3 vs e6", getsize(e3), getsize(e6))
 
-    def test_old_vs_new(self):
+    def _test_old_vs_new(self):
         '''
             - On standard events the percentage of memory saved will vary greatly and 
                 will likely decrease with larger events.  However, the real memory 
@@ -163,9 +164,8 @@ class TestEvent(unittest.TestCase):
         self._run_test(enumerations=times, classifier="cPickle__1:", func=lambda: cPickle.loads(cPickle.dumps(event, -1))) #neg num represents highest protocol; in 2.7 that is 2
 
     def test_dict_deprecation(self):
-        import warnings
         e = Event()
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(PendingDeprecationWarning) as w:
             e.__dict__
             assert len(w) == 1
             getattr(e, '__dict__')

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,20 +1,136 @@
 import unittest
 import json
+import pickle
+import cPickle
+import random
+import sys
+from copy import deepcopy
 from lxml import etree
 from collections import OrderedDict, Mapping
 
 from compysition.errors import ResourceNotFound, InvalidEventDataModification
 from compysition.event import (HttpEvent, Event, CompysitionException, XMLEvent, 
-    JSONEvent, JSONHttpEvent, XMLHttpEvent)
+    JSONEvent, JSONHttpEvent, XMLHttpEvent, LogEvent)
+from compysition.testutils import gen_rdm_attr_name, getsize
 
 conversion_classes = [str, etree._Element, etree._ElementTree, etree._XSLTResultTree, dict, list, OrderedDict, None.__class__]
 
 class TestEvent(unittest.TestCase):
+    
     def setUp(self):
         self.event = Event(data={'foo': 'bar'}, meta_id='123456abcdef')
 
     def test_distinct_meta_and_event_ids(self):
         self.assertNotEqual(self.event.event_id, self.event.meta_id)
+
+    def test_clone(self):
+        event = Event()
+        event2 = event.clone()
+        assert event is not event2
+        assert str(event) == str(event2)
+
+    def test_pickling(self):
+        event = Event(some_data="123")
+        assert event.some_data == "123"
+        event2 = pickle.loads(pickle.dumps(event))
+        assert event2.some_data == "123"
+        assert event is not event2
+        assert event.__getstate__() == event2.__getstate__()
+        event2.some_date = "1234"
+        assert event.__getstate__() != event2.__getstate__()
+        assert event.event_id == event2.event_id
+
+    def test_convert(self):
+        event = Event(some_data="123", data="<root>123</root>", error=Exception("OOPS"))
+        assert event.some_data == "123"
+        event2 = event.convert(XMLEvent)
+        assert event is not event2
+        assert event2.__class__ == XMLEvent
+        assert event.__class__ == Event
+        assert event.__getstate__() == event2.__getstate__()
+        assert event.data == "<root>123</root>"
+        assert etree.tostring(event2.data) =="<root>123</root>"
+        assert event.event_id == event2.event_id
+        assert event.error == event2.error
+
+    def test_dynamic_attributes(self):
+        event = Event()
+        attr_name = gen_rdm_attr_name(length=12)
+        setattr(event, attr_name, 123)
+        assert getattr(event, attr_name) == 123
+
+    def _test_slots(self):
+        '''
+            - It appears anything slotted helps decrease memory footprint.
+                (Even when __dict__ is added to slots to provide dynamicness)
+            - It also appears that slotted objects that contain __dict__ in 
+                __slots__ do not create a __dict__ until it encounters an attribute 
+                that is not in __slots__ or until __dict__ is referenced
+                (essentially not created until someone goes looking)
+            - The only cases I found where slotted objects used more memory
+                were when no attributes were defined.
+        '''
+        class eve0(object):
+            __slots__ = ("a", "b", "c")
+        class eve0_5(object): pass
+        class eve1(object):
+            __slots__ = ("a", "b", "c")
+            def __init__(self):
+                self.a, self.b, self.c = 1,2,3
+        class eve2(eve1):
+            __slots__ = ("d", "e", "__dict__")
+            def __init__(self):
+                super(eve2, self).__init__()
+                self.d, self.e, self.f, self.g= 4,5,6,7
+        class eve3(eve2):
+            __slots__ = ("h", "i")
+            def __init__(self):
+                super(eve3, self).__init__()
+                self.h, self.i, self.j, self.k = 4,5,6,7
+        class eve4(object):
+            def __init__(self):
+                self.a, self.b, self.c = 1,2,3
+        class eve5(eve4):
+            def __init__(self):
+                super(eve5, self).__init__()
+                self.d, self.e, self.f, self.g = 4,5,6,7
+        class eve6(eve5):
+            def __init__(self):
+                super(eve6, self).__init__()
+                self.h, self.i, self.j, self.k = 4,5,6,7
+        e0, e0_5, e1, e2, e3, e4, e5, e6 = eve0(), eve0_5(), eve1(), eve2(), eve3(), eve4(), eve5(), eve6()
+        print("")
+        print("e0 vs e0_5", getsize(e0), getsize(e0_5))
+        e0_5.__dict__
+        print("e0 vs e0_5", getsize(e0), getsize(e0_5))
+        print("e1 vs e4", getsize(e1), getsize(e4))
+        print("e2 vs e5", getsize(e2), getsize(e5))
+        print("e3 vs e6", getsize(e3), getsize(e6))
+
+    def _run_test(self, enumerations, classifier, func):
+        import time
+        start = time.time()
+        for _ in range(enumerations):
+            func()
+        print(classifier, time.time() - start)
+
+    def _test_pickle_speeds(self):
+        #it appears cpickle with the highest protocol (-1/2) is the fastest .. even faster than deepcopy
+        #supposedly deepcopy uses pickling
+        times  = 5000
+        event = Event()
+        print("")
+        self._run_test(enumerations=times, classifier="Copy:", func=lambda: deepcopy(event))
+        self._run_test(enumerations=times, classifier="Pickle:", func=lambda: pickle.loads(pickle.dumps(event))) #default protocol is 0
+        self._run_test(enumerations=times, classifier="Pickle_0:", func=lambda: pickle.loads(pickle.dumps(event, 0)))
+        self._run_test(enumerations=times, classifier="Pickle_1:", func=lambda: pickle.loads(pickle.dumps(event, 1)))
+        self._run_test(enumerations=times, classifier="Pickle_2:", func=lambda: pickle.loads(pickle.dumps(event, 2)))
+        self._run_test(enumerations=times, classifier="Pickle__1:", func=lambda: pickle.loads(pickle.dumps(event, -1)))
+        self._run_test(enumerations=times, classifier="cPickle:", func=lambda: cPickle.loads(cPickle.dumps(event)))
+        self._run_test(enumerations=times, classifier="cPickle_0:", func=lambda: cPickle.loads(cPickle.dumps(event, 0)))
+        self._run_test(enumerations=times, classifier="cPickle_1:", func=lambda: cPickle.loads(cPickle.dumps(event, 1)))
+        self._run_test(enumerations=times, classifier="cPickle_2:", func=lambda: cPickle.loads(cPickle.dumps(event, 2)))
+        self._run_test(enumerations=times, classifier="cPickle__1:", func=lambda: cPickle.loads(cPickle.dumps(event, -1))) #neg num represents highest protocol; in 2.7 that is 2
 
 class TestHttpEvent(unittest.TestCase):
     def test_default_status(self):
@@ -155,6 +271,11 @@ class TestHttpEvent(unittest.TestCase):
         assert json_event.data['candy'][0]['apple'] == '2'
         assert json_event.data['candy'][1]['grape'] == '3'
 
+    def test_setting_errors(self):
+        event = HttpEvent()
+        event.error = CompysitionException("OOPS")
+        event2 = event.clone()
+        event2.error = CompysitionException("OOPS")
 
 parser = etree.XMLParser(remove_blank_text=True)
 #used to ignore spacing differences and look at basic XML structure

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -162,6 +162,21 @@ class TestEvent(unittest.TestCase):
         self._run_test(enumerations=times, classifier="cPickle_2:", func=lambda: cPickle.loads(cPickle.dumps(event, 2)))
         self._run_test(enumerations=times, classifier="cPickle__1:", func=lambda: cPickle.loads(cPickle.dumps(event, -1))) #neg num represents highest protocol; in 2.7 that is 2
 
+    def test_dict_deprecation(self):
+        import warnings
+        e = Event()
+        with warnings.catch_warnings(record=True) as w:
+            e.__dict__
+            assert len(w) == 1
+            getattr(e, '__dict__')
+            assert len(w) == 2
+            e.__dict__.update({"random_attr": 111})
+            assert len(w) == 3
+            e.__dict__['_event_id']
+            assert len(w) == 4
+            e.__getstate__()
+            assert len(w) == 4
+
 class TestHttpEvent(unittest.TestCase):
     def test_default_status(self):
         self.event = HttpEvent(data='quick brown fox')

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -107,6 +107,34 @@ class TestEvent(unittest.TestCase):
         print("e2 vs e5", getsize(e2), getsize(e5))
         print("e3 vs e6", getsize(e3), getsize(e6))
 
+    def test_old_vs_new(self):
+        '''
+            - On standard events the percentage of memory saved will vary greatly and 
+                will likely decrease with larger events.  However, the real memory 
+                saver is LogEvents. The comparison here on LogEvents is probably pretty 
+                close to representing memory usage in a live scenario.
+            - NOTE: The number of LogEvents in a live scenario likely exceeds the 
+                number of all other event types combined.
+        '''
+        from compysition.testutils.event_old import Event as OEvent, LogEvent as OLogEvent
+
+        event_kwargs = {
+            "data": {"some":"data", "goes":[1,2,3,4], "in": {"here": "but", "nothing":{"too": "big"}}},
+            "service": "sample_serice",
+            "_error": InvalidEventDataModification("OOPS You did something bad"),
+            "status": (200, "OK"),
+            "environment": gen_rdm_attr_name(length=1000)
+        }
+        logevent_kwargs = {
+            "level": "INFO",
+            "origin_actor": gen_rdm_attr_name(length=50),
+            "message": gen_rdm_attr_name(length=200)
+        }
+
+        print()
+        print("OE vs E", getsize(OEvent(**event_kwargs)), getsize(Event(**event_kwargs)))
+        print("OLE vs LE", getsize(OLogEvent(**logevent_kwargs)), getsize(LogEvent(**logevent_kwargs)))
+
     def _run_test(self, enumerations, classifier, func):
         import time
         start = time.time()


### PR DESCRIPTION
Added __slots__ to event classes.  My primary concerns with this were reducing the memory footprint while maintaining dynamicness.  Adding slots for known event attributes alongside __dict__ still decreases the size of the __dict__.  The size of the __dict__ is determined by the use of none slotted attributes and is only created when referenced.  The adding of slots makes pickling slightly slower but helps reduce memory footprint and is more than offset by the included pickling changes.  See memory tests in test_events.py.

Improved pickling functionalities.  There are several pickling protocols that increase in efficiency as the protocol level increases.  We were using the lowest in mdpactors.py.  It also turns out pickling and unpickling an Event is faster than deepcopy and performs the same function.  By utilizing that knowledge I was able to improve the speed at which we send events between actors.  See speed tests in test_actors.py and test_events.py.